### PR TITLE
Bug 1797244 - Update the paths to the strings xml

### DIFF
--- a/src/sync-strings.py
+++ b/src/sync-strings.py
@@ -45,7 +45,7 @@ def all_strings_xml_paths(repo_path, locales):
         main_l10n_toml = tomlkit.loads(main_toml_fp.read())
         for locale in locales:
             pathname = main_l10n_toml["paths"][0]["l10n"].replace("{android_locale}", android_locale(locale))
-            for strings_xml_path in glob.glob(os.path.join(repo_path, pathname), recursive=True):
+            for strings_xml_path in glob.glob(os.path.join(repo_path, "android-components", pathname), recursive=True):
                 yield os.path.relpath(strings_xml_path, repo_path)
 
 


### PR DESCRIPTION
We are updating the paths in this script since we had to take out the `android-components/` from the `l10n.toml` in https://github.com/mozilla-mobile/firefox-android/commit/293174cb840491681de4c512f8140f33ae05e60e. 